### PR TITLE
Fix for not being able to show certain functionaries

### DIFF
--- a/app/views/people/show.html.haml
+++ b/app/views/people/show.html.haml
@@ -71,6 +71,7 @@
       %th Till
     - @person.functionaries.sorted.each do |func|
       %tr
-        %td= link_to func.chapter_post.name, func.chapter_post
-        %td= func.active_from
-        %td= func.active_to
+        - if func.chapter_post.name.present?
+          %td= link_to func.chapter_post.name, func.chapter_post
+          %td= func.active_from
+          %td= func.active_to


### PR DESCRIPTION
Något osäker på syntaxen, men det behövs en nil-check för att inte få en 'undefined method for nil'.
Som det ser ut just nu kan inte vissa personers hemsida visas pga fel med funktionärsposter.
