### PR TITLE
Display KTH ID on hover in the menu

### DIFF
--- a/app/views/layouts/_loginout.html.haml
+++ b/app/views/layouts/_loginout.html.haml
@@ -4,9 +4,7 @@
     Du är ej inloggad.
     = link_to 'logga in', new_sessions_path(:return_url => current_url), :class => 'do'
   - else 
-    = link_to person, :title => "Inloggad som #{person.name}", :class => 'person' do
+    = link_to person, :title => "Inloggad som #{person.kth_username}", :class => 'person' do
       %span= person.name
       = image_tag(person.gravatar_url, :class => 'thumb', :alt => '', :title => person)
     = link_to 'logga ut', logout_path(:return_url => current_url), :class => 'do'
-
-


### PR DESCRIPTION
Display KTH ID instead of name when hovering over username at the login/logout menu
